### PR TITLE
feat: Add minimize-to-tray functionality for manager window

### DIFF
--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -159,7 +159,7 @@ pub mod defaults {
         pub const WINDOW_WIDTH: u16 = 700;
 
         /// Default Manager window height in pixels
-        pub const WINDOW_HEIGHT: u16 = 450;
+        pub const WINDOW_HEIGHT: u16 = 470;
     }
 
     /// Thumbnail window settings

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -180,6 +180,8 @@ pub struct GlobalSettings {
     pub backup_interval_days: u32,
     #[serde(default = "default_backup_retention_count")]
     pub backup_retention_count: u32,
+    #[serde(default)]
+    pub minimize_to_tray: bool,
 }
 
 /// Profile - A complete set of visual and behavioral settings
@@ -414,6 +416,7 @@ impl Default for GlobalSettings {
             backup_enabled: default_backup_enabled(),
             backup_interval_days: default_backup_interval_days(),
             backup_retention_count: default_backup_retention_count(),
+            minimize_to_tray: false,
         }
     }
 }

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -37,6 +37,7 @@ struct ManagerApp {
     update_signal: std::sync::Arc<tokio::sync::Notify>,
 
     active_tab: ManagerTab,
+    window_visible: bool,
 }
 
 impl ManagerApp {
@@ -167,6 +168,7 @@ impl ManagerApp {
             characters_state,
             sources_state: components::sources::SourcesTab::default(),
             active_tab: ManagerTab::Behavior,
+            window_visible: true,
         };
 
         #[cfg(not(target_os = "linux"))]
@@ -179,6 +181,7 @@ impl ManagerApp {
             characters_state,
             sources_state: components::sources::SourcesTab::default(),
             active_tab: ManagerTab::Behavior,
+            window_visible: true,
         };
 
         app
@@ -210,6 +213,28 @@ impl eframe::App for ManagerApp {
         // Track window geometry changes and update config
         // Clone viewport info to avoid lifetime issues
         let viewport_info = ctx.input(|i| i.viewport().clone());
+
+        // Handle minimize-to-tray functionality
+        // Check if window was just minimized by detecting the minimize event
+        if state.config.global.minimize_to_tray && self.window_visible {
+            let is_minimized = viewport_info.minimized.unwrap_or(false);
+            
+            if is_minimized {
+                // Immediately hide the window and restore it from minimized state
+                ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+                self.window_visible = false;
+            }
+        }
+        
+        // Track when window becomes visible again (e.g., from tray icon click)
+        // Check if we're not minimized and not hidden
+        if !self.window_visible {
+            let is_minimized = viewport_info.minimized.unwrap_or(false);
+            if !is_minimized {
+                self.window_visible = true;
+            }
+        }
 
         // Try to get window size from viewport inner_rect first, fall back to content_rect
         let (new_width, new_height) = if let Some(inner_rect) = viewport_info.inner_rect {

--- a/src/manager/components/behavior_settings.rs
+++ b/src/manager/components/behavior_settings.rs
@@ -115,6 +115,19 @@ pub fn ui(
 
             ui.add_space(ITEM_SPACING);
 
+            // Minimize to tray
+            if ui.checkbox(&mut global.minimize_to_tray,
+                "Minimize to system tray").changed() {
+                action = BehaviorSettingsAction::SettingsChanged;
+            }
+
+            ui.label(egui::RichText::new(
+                "When enabled, minimizing the window hides it to the system tray")
+                .small()
+                .weak());
+
+            ui.add_space(ITEM_SPACING);
+
             // Hide when no focus
             if ui.checkbox(&mut profile.thumbnail_hide_not_focused,
                 "Hide thumbnails when EVE loses focus").changed() {

--- a/src/manager/components/tray.rs
+++ b/src/manager/components/tray.rs
@@ -43,6 +43,13 @@ impl ksni::Tray for AppTray {
             .unwrap_or_default()
     }
 
+    fn activate(&mut self, _x: i32, _y: i32) {
+        // Left-click on tray icon shows the window
+        self.ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+        self.ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+        self.ctx.request_repaint();
+    }
+
     fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
         use ksni::menu::*;
 
@@ -63,6 +70,19 @@ impl ksni::Tray for AppTray {
         };
 
         vec![
+            // Show Window item
+            StandardItem {
+                label: "Show Window".into(),
+                activate: Box::new(|this: &mut AppTray| {
+                    this.ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+                    this.ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+                    this.ctx.request_repaint();
+                }),
+                ..Default::default()
+            }
+            .into(),
+            // Separator
+            MenuItem::Separator,
             // Refresh item
             StandardItem {
                 label: "Refresh".into(),


### PR DESCRIPTION
# Add Minimize-to-Tray Functionality

## Description

This PR adds the ability to minimize the EVE Preview Manager window to the system tray instead of the taskbar.

## Changes

### Configuration
- Added `minimize_to_tray` boolean field to `GlobalSettings` struct in `src/config/profile.rs`
- Defaults to `false` to maintain existing behavior for current users

### User Interface
- Added checkbox toggle in Behavior Settings tab (`src/manager/components/behavior_settings.rs`)
- Includes descriptive help text explaining the feature

### Window Management
- Implemented minimize event detection in `src/manager/app.rs`
- When minimize is detected and feature is enabled:
  - Window is immediately un-minimized
  - Window visibility is set to hidden
  - Prevents taskbar flash before hiding to tray
- Added window visibility state tracking

### System Tray Integration
- Added "Show Window" menu item to tray context menu (`src/manager/components/tray.rs`)
- Implemented `activate()` method to handle left-click on tray icon
- Both left-click and "Show Window" menu item restore and focus the window

## Testing

Tested on CachyOS (Arch-based) with Wayland:
- ✅ Minimize to tray works without taskbar appearance
- ✅ Left-click tray icon restores window
- ✅ Right-click menu "Show Window" option works
- ✅ Feature can be toggled on/off in settings
- ✅ Configuration persists across restarts
- ✅ Default behavior unchanged when feature is disabled

## Screenshots

N/A - Feature is functional but UI changes are minimal (single checkbox)

## Breaking Changes

None. Feature is opt-in and disabled by default.

## Author

Co-authored-by: Cascade AI <cascade@windsurf.ai>