### PR TITLE
Mouse Position Registered On Neocom Menu After Cycle

### DIFF
--- a/src/daemon/main_loop.rs
+++ b/src/daemon/main_loop.rs
@@ -14,7 +14,7 @@ use crate::common::constants::eve;
 use crate::common::ipc::{BootstrapMessage, ConfigMessage, DaemonMessage};
 use crate::config::DaemonConfig;
 use crate::input::listener::{self, CycleCommand, TimestampedCommand};
-use crate::x11::{AppContext, CachedAtoms, activate_window, minimize_window, unminimize_window};
+use crate::x11::{AppContext, CachedAtoms, activate_window, minimize_window, unminimize_window, force_pointer_refresh};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 
 use super::cycle_state::CycleState;
@@ -595,7 +595,9 @@ async fn run_event_loop(
                                     }
                                 }
                             }
-
+                            
+                            // Inject synthetic motion event to fix "stuck mouse" issues on XWayland where hover states don't activate after focus changes.
+                            force_pointer_refresh(ctx.conn, window, timestamp).context("Failed to refresh pointer state after hotkey activation")?;
                             // CRITICAL: Flush X11 connection to ensure border updates are rendered
                             // before the 25ms delay. Without this, borders may flash to wrong clients.
                             let _ = ctx.conn.flush();

--- a/src/x11/ops.rs
+++ b/src/x11/ops.rs
@@ -47,13 +47,23 @@ pub fn activate_window(
         "Failed to send _NET_ACTIVE_WINDOW event for window {}",
         window
     ))?;
-    
+
     // Inject a synthetic motion event to wake up the client's input handling
     // This fixes "stuck mouse" issues on XWayland where hover states don't activate
     refresh_pointer_state(conn, window, timestamp).context("Failed to refresh pointer state")?;
 
     conn.flush()
         .context("Failed to flush X11 connection after window activation")?;
+    Ok(())
+}
+
+
+// Create a wrapper function for for the syntehic moition even so it can be called else where
+pub fn force_pointer_refresh(conn: &RustConnection, window: Window, timestamp: u32) -> Result<()> {
+    
+    refresh_pointer_state(conn, window, timestamp).context("Failed to refresh pointer state")?;
+    conn.flush()
+        .context("Failed to flush X11 connection after pointer refresh")?;
     Ok(())
 }
 
@@ -191,12 +201,13 @@ fn refresh_pointer_state(conn: &RustConnection, window: Window, timestamp: u32) 
         sequence: 0,
         time: timestamp,
         root: 0, // Not needed for this hack
+        root: 0, // Not needed for this hack
         event: window,
         child: window,
-        root_x: -1,  // Not needed
-        root_y: -1,  // Not needed
-        event_x: -1, // Not needed, client usually re-polls or just seeing the event is enough
-        event_y: -1, // Not needed
+        root_x: 0,  // Not needed
+        root_y: 0,  // Not needed
+        event_x: 0, // Not needed, client usually re-polls or just seeing the event is enough
+        event_y: 0, // Not needed
         state: KeyButMask::default(),
         same_screen: true,
     };

--- a/src/x11/ops.rs
+++ b/src/x11/ops.rs
@@ -193,36 +193,47 @@ pub fn unminimize_window(
 ///
 /// Use this instead of WarpPointer on Wayland sessions.
 fn refresh_pointer_state(conn: &RustConnection, window: Window, timestamp: u32) -> Result<()> {
-    // Construct a synthetic MotionNotify event
-    // The goal is to tell the client "the mouse is right here" without moving it physically.
+    let pointer = conn
+        .query_pointer(window)
+        .context("Failed to query pointer for refresh_pointer_state")?
+        .reply()
+        .context("Failed to get QueryPointer reply for refresh_pointer_state")?;
+
+    // Determine jitter direction to avoid going out of bounds (0,0)
+    // If we are at the very top/left, move +1, otherwise move -1.
+    let jitter_x = if pointer.root_x > 0 { -1 } else { 1 };
+    let jitter_y = if pointer.root_y > 0 { -1 } else { 1 };
+
     let motion_event = MotionNotifyEvent {
         response_type: MOTION_NOTIFY_EVENT,
         detail: Motion::NORMAL,
         sequence: 0,
         time: timestamp,
-        root: 0, // Not needed for this hack
-        root: 0, // Not needed for this hack
+        root: pointer.root,
         event: window,
-        child: window,
-        root_x: 0,  // Not needed
-        root_y: 0,  // Not needed
-        event_x: 0, // Not needed, client usually re-polls or just seeing the event is enough
-        event_y: 0, // Not needed
-        state: KeyButMask::default(),
-        same_screen: true,
+        child: pointer.child,
+        root_x: pointer.root_x + jitter_x,
+        root_y: pointer.root_y + jitter_y,
+        event_x: pointer.win_x + jitter_x,
+        event_y: pointer.win_y + jitter_y,
+        // Use default to ensure we don't accidentally trigger "Drag" logic 
+        // if a mouse button was physically held during this call.
+        state: KeyButMask::default(), 
+        same_screen: true, // Force the client to treat it as a local event
     };
 
-    // Send the event directly to the window
     conn.send_event(
-        false,                     // propagate
-        window,                    // destination
-        EventMask::POINTER_MOTION, // event mask
-        motion_event,              // event content
+        false,                     
+        window,                    
+        EventMask::POINTER_MOTION, 
+        motion_event,              
     )?;
 
     tracing::debug!(
         window = window,
-        "Injected synthetic MotionNotify to refresh pointer state"
+        x = pointer.root_x + jitter_x,
+        y = pointer.root_y + jitter_y,
+        "Injected synthetic MotionNotify with default mask and same_screen: true"
     );
 
     Ok(())

--- a/src/x11/ops.rs
+++ b/src/x11/ops.rs
@@ -47,7 +47,7 @@ pub fn activate_window(
         "Failed to send _NET_ACTIVE_WINDOW event for window {}",
         window
     ))?;
-
+    
     // Inject a synthetic motion event to wake up the client's input handling
     // This fixes "stuck mouse" issues on XWayland where hover states don't activate
     refresh_pointer_state(conn, window, timestamp).context("Failed to refresh pointer state")?;
@@ -185,20 +185,27 @@ pub fn unminimize_window(
 fn refresh_pointer_state(conn: &RustConnection, window: Window, timestamp: u32) -> Result<()> {
     // Construct a synthetic MotionNotify event
     // The goal is to tell the client "the mouse is right here" without moving it physically.
+
+    let pointer = conn
+        .query_pointer(window)
+        .context("Failed to query pointer for refresh_pointer_state")?
+        .reply()
+        .context("Failed to get QueryPointer reply for refresh_pointer_state")?;
+
     let motion_event = MotionNotifyEvent {
         response_type: MOTION_NOTIFY_EVENT,
         detail: Motion::NORMAL,
         sequence: 0,
         time: timestamp,
-        root: 0, // Not needed for this hack
+        root: pointer.root,
         event: window,
-        child: window,
-        root_x: 0,  // Not needed
-        root_y: 0,  // Not needed
-        event_x: 0, // Not needed, client usually re-polls or just seeing the event is enough
-        event_y: 0, // Not needed
-        state: KeyButMask::default(),
-        same_screen: true,
+        child: pointer.child,
+        root_x: pointer.root_x,
+        root_y: pointer.root_y,
+        event_x: pointer.win_x,
+        event_y: pointer.win_y,
+        state: pointer.mask,
+        same_screen: pointer.same_screen,
     };
 
     // Send the event directly to the window

--- a/src/x11/ops.rs
+++ b/src/x11/ops.rs
@@ -185,27 +185,20 @@ pub fn unminimize_window(
 fn refresh_pointer_state(conn: &RustConnection, window: Window, timestamp: u32) -> Result<()> {
     // Construct a synthetic MotionNotify event
     // The goal is to tell the client "the mouse is right here" without moving it physically.
-
-    let pointer = conn
-        .query_pointer(window)
-        .context("Failed to query pointer for refresh_pointer_state")?
-        .reply()
-        .context("Failed to get QueryPointer reply for refresh_pointer_state")?;
-
     let motion_event = MotionNotifyEvent {
         response_type: MOTION_NOTIFY_EVENT,
         detail: Motion::NORMAL,
         sequence: 0,
         time: timestamp,
-        root: pointer.root,
+        root: 0, // Not needed for this hack
         event: window,
-        child: pointer.child,
-        root_x: pointer.root_x,
-        root_y: pointer.root_y,
-        event_x: pointer.win_x,
-        event_y: pointer.win_y,
-        state: pointer.mask,
-        same_screen: pointer.same_screen,
+        child: window,
+        root_x: -1,  // Not needed
+        root_y: -1,  // Not needed
+        event_x: -1, // Not needed, client usually re-polls or just seeing the event is enough
+        event_y: -1, // Not needed
+        state: KeyButMask::default(),
+        same_screen: true,
     };
 
     // Send the event directly to the window


### PR DESCRIPTION
Okay I might have a fix for my issue: https://github.com/h0lylag/EVE-Preview-Manager/issues/17

It is a pretty simple fix but I think it address the issue? Instead of setting the mouse x,y to 0,0 I just set it to -1,-1 which I assume is "off screen/window". That way the game client does not see the mouse point register as 0,0 briefly.

Sorry I am by no means a rust, gui or X11 developer so if I am way out to lunch here I understand. Just trying to see if there was a simple fix.