### PR TITLE
ci: skip FlakeHub publish for prereleases

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,8 +1,7 @@
 name: "Publish tags to FlakeHub"
 on:
-  push:
-    tags:
-      - "v?[0-9]+.[0-9]+.[0-9]+*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -11,6 +10,18 @@ on:
         required: true
 jobs:
   flakehub-publish:
+    if: >-
+      ${{
+        (
+          github.event_name == 'release' &&
+          github.event.release.prerelease == false &&
+          !contains(github.event.release.tag_name, '-')
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          !contains(inputs.tag, '-')
+        )
+      }}
     runs-on: "ubuntu-latest"
     permissions:
       id-token: "write"
@@ -19,11 +30,11 @@ jobs:
       - uses: "actions/checkout@v5"
         with:
           persist-credentials: false
-          ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
+          ref: "${{ format('refs/tags/{0}', github.event.release.tag_name || inputs.tag) }}"
       - uses: "DeterminateSystems/determinate-nix-action@v3"
       - uses: "DeterminateSystems/flakehub-push@main"
         with:
           visibility: "public"
           name: "h0lylag/EVE-Preview-Manager"
-          tag: "${{ inputs.tag }}"
+          tag: "${{ github.event.release.tag_name || inputs.tag }}"
           include-output-paths: true


### PR DESCRIPTION
Trigger FlakeHub publishing from GitHub release publication instead of tag pushes so the workflow can respect the prerelease flag.

Also guard manual dispatches against prerelease-style semver tags containing a hyphen, such as v1.2.3-rc.1.